### PR TITLE
Adapt coverage.py script to work with cmake projects.

### DIFF
--- a/coveralls/coverage.py
+++ b/coveralls/coverage.py
@@ -45,9 +45,9 @@ def run_gcov(args):
             basename, ext = os.path.splitext(filepath)
             if ext == '.gcno':
                 if re.search(r".*\.c.*", basename):
-                      subprocess.call('cd %s && %s %s.o' % (root, args.gcov, basename),
+                    subprocess.call('cd %s && %s %s.o' % (root, args.gcov, basename),
                                     shell=True) 
-		else:
+                else:
                     subprocess.call('cd %s && %s %s' % (root, args.gcov, basename),
                                     shell=True)
 


### PR DESCRIPTION
Cmake projects generates files which contain the file extension, e.g. compiling sourcefile.cpp creates sourcefile.cpp.gcno. Calling "gcov sourcefile.cpp" doesn't work and in such situations "gcov sourcefile.cpp.o" should be called instead.
