### PR TITLE
Treat git output as UTF-8

### DIFF
--- a/coveralls/gitrepo.py
+++ b/coveralls/gitrepo.py
@@ -45,11 +45,11 @@ def gitrepo(self):
 
 
 def gitlog(format):
-    return str(git('--no-pager', 'log', '-1', '--pretty=format:%s' % format))
+    return git('--no-pager', 'log', '-1', '--pretty=format:%s' % format)
 
 
 def git(*arguments):
     """Return output from git."""
     process = subprocess.Popen(['git'] + list(arguments),
                                stdout=subprocess.PIPE)
-    return process.communicate()[0].decode(locale.getpreferredencoding(False))
+    return process.communicate()[0].decode('UTF-8')


### PR DESCRIPTION
My problem is in https://travis-ci.org/chewing/libchewing/jobs/9887331, where the author contains UTF-8 character. Because the output of `locale.getpreferredencoding(False)` is `ANSI_X3.4-1968`, the `decode` will raise `UnicodeDecodeError`.

In this patch, I just assume the output of git is UTF-8 encoding, and using unicode interface to handle them. Although git can handle encoding other than UTF-8, UTF-8 is preferred encoding, and using legacy encoding will cause warning according to [git document](https://www.kernel.org/pub/software/scm/git/docs/git-commit.html#_discussion).
