### PR TITLE
enable the use of a build directory and add access to gcov options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,24 @@ Inspired from [z4r/python-coveralls](https://github.com/z4r/python-coveralls), i
 
 ```sh
 $ coveralls -h
-usage: coveralls [-h] [--gcov FILE] [-r DIR] [-e DIR|FILE] [-x EXT] [-y FILE]
+usage: coveralls [-h] [--gcov FILE] [--gcov-options GCOV_OPTS] [-r DIR]
+                 [-b DIR] [-e DIR|FILE] [-E REGEXP] [-x EXT] [-y FILE] [-n]
                  [-t TOKEN] [--verbose]
 
 optional arguments:
   -h, --help            show this help message and exit
   --gcov FILE           set the location of gcov
+  --gcov-options GCOV_OPTS
+                        set the options given to gcov
   -r DIR, --root DIR    set the root directory
+  -b DIR, --build-root DIR
+                        set the directory from which gcov will be called. By
+                        default gcov is run in the directory of the .o files.
+                        However the paths of the sources are often relative to
+                        the directory from which the compiler was run and
+                        these relative paths are saved in the .o file. When
+                        this happens, gcov needs to run in the same directory
+                        as the compiler in order to find the source files.
   -e DIR|FILE, --exclude DIR|FILE
                         set exclude file or directory
   -E REGEXP, --exclude-pattern REGEXP

--- a/coveralls/coverage.py
+++ b/coveralls/coverage.py
@@ -14,7 +14,7 @@ def create_args(params):
     parser.add_argument('--gcov', metavar='FILE', default='gcov',
                         help='set the location of gcov')
     parser.add_argument('--gcov-options', metavar="GCOV_OPTS", default='',
-                        help='give these options to gcov')
+                        help='set the options given to gcov')
     parser.add_argument('-r', '--root', metavar='DIR', default='.',
                         help='set the root directory')
     parser.add_argument('-b', '--build-root', metavar='DIR',


### PR DESCRIPTION
Most build systems enable the use of a build directory. This directory contains object files but not sources.

Here are the problems I encountered when using cpp-coveralls and which I resolve with these commits:

First, the building commands (g++, ld ...) are called in the build directory with relative paths. For example with a build directory "build" at the root of the project, g++ will be called like this "g++ ../src/.../main.cpp". The resulting .gcda .gcno files will contain the relative path "../src/.../main.cpp" which cannot be found relatively to the root of the project or to the directory of the object file. As gcov is called in this last directory, it cannot find the sources and fails.
I fix this by adding the option --build-root. This option calls gcov in the given build root directory. Thus the relative paths are valid.

Second, old versions of gcov (before 4.7) do not search the .gcda .gcno files in the same folder as the object file. It searches instead those files in the directory where it is invoked. Thus we use the gcov's --object-directory option which gives the directory where the .o files are located when using the cpp-coverall's --build-root option.

I also added the --gcov-options option which enables the user to give specific options to gcov. This way he may use options like --relative-only which is available in gcc 4.7 and generates a lot less gcov files.

You can find a basic project using these new features here: https://github.com/nharraud/testTravis
