### PR TITLE
Filter paths consistently for executed and unexecuted files.

### DIFF
--- a/coveralls/coverage.py
+++ b/coveralls/coverage.py
@@ -228,9 +228,10 @@ def collect(args):
         for filename in files:
             if not is_source_file(args, filename):
                 continue
-            if is_excluded_path(args, filename):
+            abs_filepath = os.path.join(abs_root, filename)
+            if is_excluded_path(args, abs_filepath):
                 continue
-            filepath = os.path.relpath(os.path.join(root, filename), abs_root)
+            filepath = os.path.relpath(abs_filepath, abs_root)
             if not filepath in discoverd_files:
                 src_report = {}
                 src_report['name'] = filepath


### PR DESCRIPTION
Previously we only passed the basename to the exclusion path
checker, which, if that was checking a pathname component, wouldn't
work for unexecuted files. Pass the absolute path like we do when
reading the .gcov file.

Fixes eddyxu/cpp-coveralls#19 .
