### PR TITLE
Fix file extension literal.

### DIFF
--- a/coveralls/coverage.py
+++ b/coveralls/coverage.py
@@ -11,7 +11,7 @@ import subprocess
 from . import gitrepo
 
 
-_CPP_EXTENSIONS = ['.h', '.hpp', '.cpp', '.cc', 'c']
+_CPP_EXTENSIONS = ['.h', '.hpp', '.cpp', '.cc', '.c']
 
 
 def create_args(params):


### PR DESCRIPTION
```
_CPP_EXTENSIONS = ['.h', '.hpp', '.cpp', '.cc', 'c']
```

This line seems a copy error on this commit https://github.com/eddyxu/cpp-coveralls/commit/77818c0ee75f1bd0fb84b494bcc372021ece8d5a .
