### PR TITLE
Respect "LCOV_EXCL_LINE" exclusions

### DIFF
--- a/coveralls/coverage.py
+++ b/coveralls/coverage.py
@@ -217,8 +217,11 @@ def collect(args):
                             coverage.append(None)
                         elif cov_num == '#####':
                             # Avoid false positives.
-                            if (text.lstrip().startswith('static') or
-                                    text.strip() == '}'):
+                            if (
+                                text.lstrip().startswith('static') or
+                                text.strip() == '}' or
+                                re.match(r'.*//\s*LCOV_EXCL_LINE\s*', text)
+                            ):
                                 coverage.append(None)
                             else:
                                 coverage.append(0)


### PR DESCRIPTION
This adds support for the `LCOV_EXCL_LINE` line exclusion syntax used by [lcov](http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php). This is useful for excluding lines that are missed due to the compiler's return value optimization.
