### PR TITLE
Use correct OS name

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ after_success:
   - coveralls --exclude lib --exclude tests
 ```
 
-### MacOS X
+### OS X
 
-*Python* on *MacOS* can be a bit of a hassle so you need to install to set up your custom environment:
+*Python* on *OS X* can be a bit of a hassle so you need to install to set up your custom environment:
 
 ```
 language: objective-c


### PR DESCRIPTION
It is called "OS X".

http://www.theverge.com/2012/2/16/2802281/apple-officially-renames-mac-os-x-to-os-x-drops-the-mac
