### PR TITLE
Remove "--use-mirrors"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ language: cpp
 compiler:
   - gcc
 before_install:
-  - sudo pip install cpp-coveralls --use-mirrors
+  - sudo pip install cpp-coveralls
 script:
   - ./configure --enable-gcov && make && make check
 after_success:


### PR DESCRIPTION
It is obsolete.

https://pip.readthedocs.org/en/latest/news.html
