### PR TITLE
Handle more extensions + fix relative paths

### DIFF
--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -224,7 +224,7 @@ def collect_non_report_files(args, discovered_files):
                 src_report = {}
                 src_report['name'] = filepath
                 coverage = []
-                with io.open(filepath, encoding=args.encoding) as fobj:
+                with io.open(abs_filepath, encoding=args.encoding) as fobj:
                     for _ in fobj:
                         coverage.append(None)
                     fobj.seek(0)
@@ -277,7 +277,7 @@ def collect(args):
                     src_report = {}
                     src_report['name'] = src_path
                     discovered_files.add(src_path)
-                    with io.open(src_path, encoding=args.encoding) as src_file:
+                    with io.open(source_file_path, encoding=args.encoding) as src_file:
                         src_report['source'] = src_file.read()
 
                     src_report['coverage'] = parse_gcov_file(fobj)


### PR DESCRIPTION
- Add more C++ extensions,
- Ignore Mercurial directory,
- Fix a `FileNotFoundError`:

``` sh
./root
  |-- build
  |-- src
      `-- file.cc
```

If we run `coveralls` in `build`, `filepath` is `src/file.cc` (relative path w.r.t. `root`), and `io.open(filepath)` was executed in `build` (≠ `root` directory), leading to the error.
