### PR TITLE
Fix Git repository for report (use root directory).

### DIFF
--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -287,5 +287,6 @@ def collect(args):
     report['source_files'].extend(
         collect_non_report_files(args, discovered_files))
 
-    report['git'] = gitrepo.gitrepo('.')
+    # Use the root directory to get information on the Git repository
+    report['git'] = gitrepo.gitrepo(abs_root)
     return report


### PR DESCRIPTION
The previous code was expecting `coveralls` to be executed from the source directory. However, we may do something like:

``` sh
mkdir -p /tmp/build && cd /tmp/build
cmake /path/to/project
make && make test
coveralls -b . -r /path/to/project
```

In this case, the `build` directory is not in the Git project, leading to the following error:

``` text
fatal: Not a git repository (or any parent up to mount point /tmp)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

Thus, we use the `root` directory when looking for the Git repository.
