### PR TITLE
fix source file path generation

### DIFF
--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -267,7 +267,7 @@ def collect(args):
                                     root, source_file_path))
                         else:
                             source_file_path = os.path.abspath(
-                                os.path.join(root, source_file_path))
+                                os.path.join(abs_root if os.path.dirname(source_file_path) else root, source_file_path))
                     src_path = os.path.relpath(source_file_path, abs_root)
                     if len(src_path) > 3 and src_path[:3] == '../':
                         continue


### PR DESCRIPTION
When running `coveralls` on libtomcrypt I got the following error:

```
Traceback (most recent call last):
  File "/usr/local/bin/coveralls", line 9, in <module>
    load_entry_point('cpp-coveralls==0.2.1', 'console_scripts', 'coveralls')()
  File "/usr/local/lib/python2.7/dist-packages/cpp_coveralls/__init__.py", line 69, in run
    cov_report = coverage.collect(args)
  File "/usr/local/lib/python2.7/dist-packages/cpp_coveralls/coverage.py", line 280, in collect
    with io.open(source_file_path, encoding=args.encoding) as src_file:
IOError: [Errno 2] No such file or directory: '<my working path>/libtomcrypt/src/math/src/math/multi.c'
```

After some debugging I came up with the proposed patch
