### PR TITLE
check --dryrun after --dump

### DIFF
--- a/cpp_coveralls/__init__.py
+++ b/cpp_coveralls/__init__.py
@@ -69,10 +69,12 @@ def run():
     cov_report = coverage.collect(args)
     if args.verbose:
         print(cov_report)
-    if args.dryrun:
-        return 0
+
     if args.dump:
         args.dump.write(json.dumps(cov_report))
+        return 0
+
+    if args.dryrun:
         return 0
 
     return report.post_report(cov_report)


### PR DESCRIPTION
when using both flags, --dump was skipped

the return after the dump could also be removed, so you could send the report and dump it at the same time
