### PR TITLE
Combine multiple source files if they have the same path

### DIFF
--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -207,6 +207,8 @@ def parse_gcov_file(fobj):
     return coverage
 
 def combine_reports(original, new):
+    """Combines two gcov reports for a file into one by adding the number of hits on each line
+    """
     if original == None:
         return new
     report = {}


### PR DESCRIPTION
This would be really useful for inline functions in header files where you can end up seeing 20 different copies of a header which makes it hard to gauge the coverage. 

Please feel free to criticise the implementation as this is the first time I've written python.
