### PR TITLE
Ignore incorrectly reported lines

### DIFF
--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -192,7 +192,7 @@ def parse_gcov_file(fobj):
         elif cov_num == '#####':
             # Avoid false positives.
             if (
-                text.lstrip().startswith('static') or
+                text.lstrip().startswith(('inline', 'static')) or
                 text.strip() == '}' or
                 re.match(r'.*//\s*LCOV_EXCL_LINE\s*', text)
             ):


### PR DESCRIPTION
Similar to `static` case, coverage is not correct in the `inline` case. Coverage reports the body of the function as covered, but the declaration as not covered.

https://coveralls.io/files/239249642#L32
