### PR TITLE
Skip over messages in gcov file.

### DIFF
--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -226,6 +226,9 @@ def parse_gcov_file(fobj, filename):
     ignoring = False
     for line in fobj:
         report_fields = line.split(':')
+        if len(report_fields) == 1:
+            continue
+        
         cov_num = report_fields[0].strip()
         line_num = int(report_fields[1].strip())
         text = report_fields[2]


### PR DESCRIPTION
Gcovr was putting messages into my gcov files and breaking this script, I've amended my gcovr to run without messages but I think it'd be better if this was handled gracefully here.