### PR TITLE
cpp-coverals will now raise an exception if neither the travis job id nor the repo token are found

### DIFF
--- a/cpp_coveralls/__init__.py
+++ b/cpp_coveralls/__init__.py
@@ -67,7 +67,12 @@ def run():
     yml = parse_yaml_config(args)
 
     if not args.repo_token:
+        # try get token from yaml first
         args.repo_token = yml.get('repo_token', '')
+    if not args.repo_token:
+        # use environment COVERALLS_REPO_TOKEN as a fallback
+        args.repo_token = os.environ.get('COVERALLS_REPO_TOKEN')
+
     args.service_name = yml.get('service_name', 'travis-ci')
 
     if not args.gcov_options:
@@ -81,6 +86,10 @@ def run():
     args.include.extend(yml.get('include', []))
 
     args.service_job_id = os.environ.get('TRAVIS_JOB_ID', '')
+
+    if args.repo_token == '' and args.service_job_id == '':
+        raise ValueError("\nno coveralls.io token specified and no travis job id found\n"
+                         "see --help for examples on how to specify a token\n")
 
     if not args.no_gcov:
         coverage.run_gcov(args)

--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -328,8 +328,6 @@ def collect(args):
     report = {}
     if args.repo_token:
         report['repo_token'] = args.repo_token
-    elif os.environ.get('COVERALLS_REPO_TOKEN'):
-        report['repo_token'] = os.environ.get('COVERALLS_REPO_TOKEN')
 
     report['service_name'] = args.service_name
     report['service_job_id'] = args.service_job_id

--- a/test.bash
+++ b/test.bash
@@ -24,6 +24,11 @@ int main() {
 EOF
 gcc -coverage -o foo foo.c
 ./foo
+
+if [ -z "$TRAVIS_JOB_ID" ]; then
+    export COVERALLS_REPO_TOKEN="fake testing token"
+fi
+
 coveralls --verbose --encodings utf-8 latin-1 foobar | \
     grep '\[1, 1, 1, 0, None, None, None, None, 0, None, 1, 0, None, None, 1, None\]'
 rm -f foo foo.c* foo.gc*


### PR DESCRIPTION
This addresses the initial work raised in issue #82 but in a way that works with the existing travis workflow (travis job id)