### PR TITLE
Fix lcov exclusion keyword: end -> stop

### DIFF
--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -244,11 +244,14 @@ def parse_gcov_file(fobj, filename):
                 sys.stderr.write("Warning: %s:%d: nested LCOV_EXCL_START, "
                                  "please fix\n" % (filename, line_num))
             ignoring = True
-        elif re.search(r'\bLCOV_EXCL_END\b', text):
+        elif re.search(r'\bLCOV_EXCL_(STOP|END)\b', text):
             if not ignoring:
-                sys.stderr.write("Warning: %s:%d: LCOV_EXCL_END outside of "
+                sys.stderr.write("Warning: %s:%d: LCOV_EXCL_STOP outside of "
                                  "exclusion zone, please fix\n" % (filename,
                                                                    line_num))
+            if 'LCOV_EXCL_END' in text:
+                sys.stderr.write("Warning: %s:%d: LCOV_EXCL_STOP is the "
+                                 "correct keyword\n" % (filename, line_num))
             ignoring = False
         if cov_num == '-':
             coverage.append(None)

--- a/test.bash
+++ b/test.bash
@@ -12,7 +12,7 @@ int main() {
         /* LCOV_EXCL_START */
         a = 4;
         a = 5;
-        /* LCOV_EXCL_END */
+        /* LCOV_EXCL_STOP */
         a = 6;
     }
     if(a == 7) {


### PR DESCRIPTION
This is my fault. In #63 I added support for the lcov keywords, but I used `LCOV_EXCL_END` instead of `LCOV_EXCL_STOP`.

Some people (google finds https://github.com/mapnik/node-mapnik) use the wrong keyword, so I'm leaving it in.