### PR TITLE
Recognize APPVEYOR_REPO_BRANCH environment var.

### DIFF
--- a/cpp_coveralls/gitrepo.py
+++ b/cpp_coveralls/gitrepo.py
@@ -39,8 +39,8 @@ def gitrepo(cwd):
             'committer_email': repo.gitlog('%ce'),
             'message': repo.gitlog('%s')
         },
-        'branch': os.environ.get('TRAVIS_BRANCH', repo.git(
-            'rev-parse', '--abbrev-ref', 'HEAD').strip()),
+        'branch': os.environ.get('TRAVIS_BRANCH',
+                  os.environ.get('APPVEYOR_REPO_BRANCH',  repo.git('rev-parse', '--abbrev-ref', 'HEAD').strip())),
         'remotes': [{'name': line.split()[0], 'url': line.split()[1]}
                     for line in repo.git('remote', '-v') if '(fetch)' in line]
     }


### PR DESCRIPTION
Similar to `TRAVIS_BRANCH` environment var.  Otherwise all branches get mislabeled as `HEAD` when running inside AppVeyor.

See https://coveralls.io/github/jrfonseca/drmingw for example.