### PR TITLE
Support COVERALLS_ENDPOINT for Enterprise usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
     - "2.7"
     - "pypy"
-    - "3.2"
     - "3.3"
     - "3.4"
     - "3.5"

--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -376,7 +376,7 @@ def collect(args):
     report['service_name'] = args.service_name
     report['service_job_id'] = args.service_job_id
 
-    if os.getenv('COVERALLS_PARALLEL')
+    if os.getenv('COVERALLS_PARALLEL', False)
         report['parallel'] = 'true'
 
     discovered_files = set()

--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -376,7 +376,7 @@ def collect(args):
     report['service_name'] = args.service_name
     report['service_job_id'] = args.service_job_id
 
-    if os.getenv('COVERALLS_PARALLEL', False)
+    if os.getenv('COVERALLS_PARALLEL', False):
         report['parallel'] = 'true'
 
     discovered_files = set()

--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -376,6 +376,9 @@ def collect(args):
     report['service_name'] = args.service_name
     report['service_job_id'] = args.service_job_id
 
+    if os.getenv('COVERALLS_PARALLEL')
+        report['parallel'] = 'true'
+
     discovered_files = set()
     src_files = {}
     abs_root = os.path.abspath(args.root)

--- a/cpp_coveralls/report.py
+++ b/cpp_coveralls/report.py
@@ -3,9 +3,9 @@ from __future__ import print_function
 
 import requests
 import json
+import os
 
-URL = 'https://coveralls.io/api/v1/jobs'
-
+URL = os.getenv('COVERALLS_ENDPOINT', 'https://coveralls.io') + "/api/v1/jobs"
 
 def post_report(coverage):
     """Post coverage report to coveralls.io."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.10.0
+requests


### PR DESCRIPTION
This is needed for posting coverage to a Coveralls Enterprise instance.

More info here: https://enterprise.coveralls.io

Thank you!

Edit: added support for `COVERALLS_PARALLEL` 
(https://coveralls.zendesk.com/hc/en-us/articles/203484329-Parallel-Build-Webhook)