### PR TITLE
Adding `urllib3[secure]` to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+urllib3[secure]


### PR DESCRIPTION
Resolves issue #108
Based on docs at
https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2

I'm unsure how to test this myself at this point though.