### PR TITLE
Add option to exclude line patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ optional arguments:
                         set include file or directory
   -E REGEXP, --exclude-pattern REGEXP
                         set exclude file/directory pattern
+  --exclude-lines-pattern REGEXP
+                        set exclude lines pattern
   -x EXT, --extension EXT
                         set extension of files to process
   -y FILE, --coveralls-yaml FILE

--- a/cpp_coveralls/__init__.py
+++ b/cpp_coveralls/__init__.py
@@ -84,6 +84,7 @@ def run():
 
     args.exclude.extend(yml.get('exclude', []))
     args.include.extend(yml.get('include', []))
+    args.exclude_lines_pattern.extend(yml.get('exclude_lines_pattern', []))
 
     args.service_job_id = os.environ.get('TRAVIS_JOB_ID', '')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 urllib3[secure]
+future


### PR DESCRIPTION
This extends the functionality already provided of ignoring LCOV_EXCL_LINE and lines with only '}'.

You can now give on the command line (or in the yml) exclude-lines-pattern, a list of regex matching lines to ignore.

Moreover, this adds the default of also ignoring lines with only '};' (as created by the end of an array or a lambda).