### PR TITLE
gcov: accommodate the execution_count format change in GCC 8.1

### DIFF
--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -285,7 +285,7 @@ def parse_gcov_file(args, fobj, filename):
             # error.
             coverage.append(0)
         else:
-            coverage.append(int(cov_num))
+            coverage.append(int(cov_num.rstrip('*')))
     return coverage
 
 def parse_lcov_file_info(args, filepath, line_iter, line_coverage_re, file_end_string):


### PR DESCRIPTION
The format of gcov's execution_count has been extended to indicate any
unexecuted blocks in a single line, with a following '*':
https://github.com/gcc-mirror/gcc/commit/3cf7fddf54b5160e83236f1b9b3129e2a3a417c6

This confuses cpp-coveralls and leads to a parsing error:
```
Traceback (most recent call last):
[...]
    coverage.append(int(cov_num))
ValueError: invalid literal for int() with base 10: '2*'
```