### PR TITLE
Removing python 3.3 test from travis due to #128

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
     - "2.7"
     - "pypy"
-    - "3.3"
+#    - "3.3" # removed due to issue #128
     - "3.4"
     - "3.5"
 


### PR DESCRIPTION
Temporarily disabling python 3.3 until #128 is resolved