### PR TITLE
parse_gcov_file: handle empty/no lnum

### DIFF
--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -249,9 +249,12 @@ def parse_gcov_file(args, fobj, filename):
         report_fields = line.decode('utf-8', 'replace').split(':', 2)
         if len(report_fields) == 1:
             continue
+        line_num = report_fields[1].strip()
+        if line_num == '':
+            continue
 
         cov_num = report_fields[0].strip()
-        line_num = int(report_fields[1].strip())
+        line_num = int(line_num)
         text = report_fields[2]
         if line_num == 0:
             continue


### PR DESCRIPTION
Without this patch it would fail on the line `b'xembed_window_array_take:\n'`,
trying to cast an empty string into an int.

            -:   46:
        #####:   47:DO_ARRAY(xembed_window_t, xembed_window, DO_NOTHING)
    ------------------
    xembed_window_array_take:
        #####:   47:DO_ARRAY(xembed_window_t, xembed_window, DO_NOTHING)
    ------------------
    xembed_window_array_splice:
        #####:   47:DO_ARRAY(xembed_window_t, xembed_window, DO_NOTHING)
    ------------------
    xembed_window_array_grow:
        #####:   47:DO_ARRAY(xembed_window_t, xembed_window, DO_NOTHING)
    ------------------
            -:   48:

Using gcov (GCC) 8.2.1 20181127.