### PR TITLE
Fix malformed path by reducing path overlap

### DIFF
--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -180,7 +180,29 @@ def libtool_dir_to_source_dir(dir_path):
 
 def libtool_source_file_path(dir_path, source_file_path):
     source_dir_path = libtool_dir_to_source_dir(dir_path)
+
+    source_file_path = \
+         reduce_path_overlap(source_dir_path, source_file_path)
     return os.path.join(source_dir_path, source_file_path)
+
+
+def reduce_path_overlap(path_a, path_b):
+    # Match common path parts such as:
+    # a/b/c/d and b/c/d/e : will reduce the latter to e
+    # a/b/c/d and e       : will not change anything
+    # a/b/c/d and e/f     : will not change anything
+    pb = path_b.split(os.sep)
+    if len(pb) > 1:
+        pa = path_a.split(os.sep)
+
+        c = min(len(pa), len(pb))
+
+        while c > 0 and pa[-c:] != pb[:c]:
+            c -= 1
+        if c > 0:
+            pb = pb[c:]
+            path_b = os.sep.join(pb)
+    return path_b
 
 
 def filter_dirs(root, dirs, excl_paths):

--- a/cpp_coveralls/coverage_test.py
+++ b/cpp_coveralls/coverage_test.py
@@ -42,5 +42,23 @@ class CoverageTest(unittest.TestCase):
         self.assertTrue(coverage.is_excluded_path(args, '/src/bar/bar-and-bar.txt'))
         self.assertTrue(coverage.is_excluded_path(args, '/src/foo/subfoo/subfoo.txt'))
 
+
+    def test_reduce_path_overlap(self):
+        self.assertEqual(coverage.reduce_path_overlap('a/b/c/d',
+                                                      'b/c/d/e'),
+                         'e')
+        self.assertEqual(coverage.reduce_path_overlap('a/b/c/d',
+                                                      'e'),
+                         'e')
+        self.assertEqual(coverage.reduce_path_overlap('a/b/c/d',
+                                                      'e/f'),
+                         'e/f')
+        self.assertEqual(coverage.reduce_path_overlap('a/b/c/d',
+                                                      'd/e/f'),
+                         'e/f')
+        self.assertEqual(coverage.reduce_path_overlap('a/b/c/d',
+                                                      'e/d/f'),
+                         'e/d/f')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If source code in directory src/a, e.g. src/a/foo.c, is built using
a Makefile in src, then we may get a libtool dir of src/a/.libs and
a source file with the path a/foo.c. This cannot be joined
as src/a/a/foo.c but needs to be src/a/foo.c.

This patch implements a function that reduces path overlap between
two paths, such as the above libtool path and the source file path
so they can be joined correctly.

This PR addresses issue #135.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>