### PR TITLE
hack-ish support for Cirrus CI with antimeasures for coveralls.io behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Inspired from [z4r/python-coveralls](https://github.com/z4r/python-coveralls), i
 - `COVERALLS_REPO_TOKEN`
 - `COVERALLS_ENDPOINT`
 - `COVERALLS_PARALLEL`
+- `CI_SERVICE_NAME`
 
 
 ## Usage:

--- a/cpp_coveralls/__init__.py
+++ b/cpp_coveralls/__init__.py
@@ -73,7 +73,13 @@ def run():
         # use environment COVERALLS_REPO_TOKEN as a fallback
         args.repo_token = os.environ.get('COVERALLS_REPO_TOKEN')
 
-    args.service_name = yml.get('service_name', 'travis-ci')
+    args.service_name = yml.get('service_name', '')
+    if not args.service_name:
+        # use environment CI_SERVICE_NAME as a fallback
+        args.service_name = os.environ.get('CI_SERVICE_NAME')
+    if not args.service_name:
+        # use default 'travis-ci' as a fallback 2
+        args.service_name = 'travis-ci'
 
     if not args.gcov_options:
         args.gcov_options = yml.get('gcov_options', '')

--- a/cpp_coveralls/gitrepo.py
+++ b/cpp_coveralls/gitrepo.py
@@ -39,7 +39,7 @@ def gitrepo(cwd):
             'author_email': repo.gitlog('%ae'),
             'committer_name': repo.gitlog('%cN'),
             'committer_email': repo.gitlog('%ce'),
-            'message': repo.gitlog('%s')
+            'message': repo.gitlog('%s'),
             'rev_count': repo.git('rev-list', '--count', 'HEAD')[1].strip()
         },
         'branch': os.environ.get('TRAVIS_BRANCH',

--- a/cpp_coveralls/gitrepo.py
+++ b/cpp_coveralls/gitrepo.py
@@ -40,6 +40,7 @@ def gitrepo(cwd):
             'committer_name': repo.gitlog('%cN'),
             'committer_email': repo.gitlog('%ce'),
             'message': repo.gitlog('%s')
+            'rev_count': repo.git('rev-list', '--count', 'HEAD')[1].strip()
         },
         'branch': os.environ.get('TRAVIS_BRANCH',
                   os.environ.get('APPVEYOR_REPO_BRANCH',


### PR DESCRIPTION
Goal of this pull request:
to collect comments/ideas/criticism from actual python coders

As I'm not python programmer myself, and not an CI expert either, I hacked *this* to get away from being stuck at "Build \#1" at my project, using Cirrus CI.

Not sure if anything of this is general enough to be pulled into main version, or if I wrote it in a very non-python way, let me know if you have some thoughts about this (but it "WFM" at this moment).

If somebody else want to reuse this kind of hack, keep in mind the revision-counter from git is very flaky value, susceptible to git log history edits, etc.. For me personally this is "good enough", as I don't care too much if I will lose by accident coverage history, but if you need something more solid, it seems to me the least friction path is to just simply add also Travis CI to your project, and use the coveralls native support of it.