### PR TITLE
fix: PyYAML warning for Loader fixed

### DIFF
--- a/cpp_coveralls/__init__.py
+++ b/cpp_coveralls/__init__.py
@@ -46,7 +46,10 @@ def parse_yaml_config(args):
         with open(args.coveralls_yaml, 'r') as fp:
             if not yaml:
                 raise SystemExit('PyYAML is required for parsing configuration')
-            yml = yaml.load(fp)
+            if not yaml.FullLoader:
+                yml = yaml.load(fp, Loader=yaml.SafeLoader)
+            else:
+                yml = yaml.load(fp, Loader=yaml.FullLoader)
     except IOError:
         pass
     yml = yml or {}


### PR DESCRIPTION
with yaml.load, a code execution was possible when called without an explicit Loader.
To solve this with backwards compatibility, if the new FullLoader is found, it is used.
If it is not found, the old SafeLoader is used, Which has slightly less functionality but is safe.