### PR TITLE
Enhances branch name support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 
 python:
-    - "2.7"
-    - "pypy"
-#    - "3.3" # removed due to issue #128
-    - "3.4"
-    - "3.5"
+    - "3.7"
+    - "3.8"
+    - "3.9"
 
 install:
     - python setup.py --quiet install

--- a/cpp_coveralls/gitrepo.py
+++ b/cpp_coveralls/gitrepo.py
@@ -43,7 +43,8 @@ def gitrepo(cwd):
         },
         'branch': os.environ.get('TRAVIS_BRANCH',
                   os.environ.get('APPVEYOR_REPO_BRANCH',
-                                 repo.git('rev-parse', '--abbrev-ref', 'HEAD')[1].strip())),
+                  os.environ.get('CI_BRANCH',
+                                 repo.git('rev-parse', '--abbrev-ref', 'HEAD')[1].strip()))),
         'remotes': [{'name': line.split()[0], 'url': line.split()[1]}
                     for line in repo.git('remote', '-v')[1] if '(fetch)' in line]
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-requests
+idna>=2.5,<3
+requests>=2.25.1
 urllib3[secure]
 future


### PR DESCRIPTION
As described by the [Coveralls documentation](https://docs.coveralls.io/supported-ci-services), we can use CI_BRANCH to specify the branch on which the coverage is performed.