### PR TITLE
Added support for COVERALLS_SERVICE_NAME env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Inspired from [z4r/python-coveralls](https://github.com/z4r/python-coveralls), i
 - `COVERALLS_REPO_TOKEN`
 - `COVERALLS_ENDPOINT`
 - `COVERALLS_PARALLEL`
+- `COVERALLS_SERVICE_NAME`
 
 
 ## Usage:

--- a/cpp_coveralls/__init__.py
+++ b/cpp_coveralls/__init__.py
@@ -73,7 +73,15 @@ def run():
         # use environment COVERALLS_REPO_TOKEN as a fallback
         args.repo_token = os.environ.get('COVERALLS_REPO_TOKEN')
 
-    args.service_name = yml.get('service_name', 'travis-ci')
+    if not args.service_name:
+        # try get service name from yaml first
+        args.service_name = yml.get('service_name', '')
+    if not args.service_name:
+        # use environment COVERALLS_SERVICE_NAME as a fallback
+        args.service_name = os.environ.get('COVERALLS_SERVICE_NAME')
+    if not args.service_name:
+        # use 'travis-ci' if nothing is specified
+        args.service_name = 'travis-ci'
 
     if not args.gcov_options:
         args.gcov_options = yml.get('gcov_options', '')

--- a/cpp_coveralls/__init__.py
+++ b/cpp_coveralls/__init__.py
@@ -73,9 +73,9 @@ def run():
         # use environment COVERALLS_REPO_TOKEN as a fallback
         args.repo_token = os.environ.get('COVERALLS_REPO_TOKEN')
 
-    if not args.service_name:
-        # try get service name from yaml first
-        args.service_name = yml.get('service_name', '')
+
+    # try get service name from yaml first
+    args.service_name = yml.get('service_name', '')
     if not args.service_name:
         # use environment COVERALLS_SERVICE_NAME as a fallback
         args.service_name = os.environ.get('COVERALLS_SERVICE_NAME')


### PR DESCRIPTION
The only way until now to specify the CI service name was to use the .yml configuration file.
I added a couple lines that will also accept the `COVERALLS_SERVICE_NAME` environment variable -as per [Coveralls documentation](https://docs.coveralls.io/supported-ci-services)- while still defaulting back to `travis-ci` in case nothing is specified. 