### PR TITLE
Send service_name and service_job_id only if both are set

### DIFF
--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -376,11 +376,14 @@ def collect(args):
     excl_paths = exclude_paths(args)
 
     report = {}
+    # We should set either repo_token or service_name and service_job_id,
+    # see: https://docs.coveralls.io/api-introduction
     if args.repo_token:
         report['repo_token'] = args.repo_token
 
-    report['service_name'] = args.service_name
-    report['service_job_id'] = args.service_job_id
+    if args.service_name and args.service_job_id:
+        report['service_name'] = args.service_name
+        report['service_job_id'] = args.service_job_id
 
     if os.getenv('COVERALLS_PARALLEL', False):
         report['parallel'] = 'true'


### PR DESCRIPTION
By default we set `service_name` to `travis-ci` if `service_name` is
unset, but that in combination with an empty `service_job_id` causes all
such submitted results to end up in a single build (as they have the same
job ID) instead of the expected behavior where each submitted result has
a separate build.

The API[0] states that we should either use repo token or _both_ service
job ID and service name, so let's do just that.

[0] https://docs.coveralls.io/api-introduction