### PR TITLE
coverage discrepancy bug fix + some additional features

### DIFF
--- a/cpp_coveralls/__init__.py
+++ b/cpp_coveralls/__init__.py
@@ -90,6 +90,9 @@ def run():
     if args.service_job_id is None:
         args.service_job_id = os.environ.get('TRAVIS_JOB_ID', '')
 
+    if not args.parallel:
+        args.parallel = os.getenv('COVERALLS_PARALLEL', False)
+
     if args.repo_token == '' and args.service_job_id == '':
         raise ValueError("\nno coveralls.io token specified and no travis job id found\n"
                          "see --help for examples on how to specify a token\n")
@@ -105,4 +108,9 @@ def run():
         args.dump.write(json.dumps(cov_report))
         return 0
 
-    return report.post_report(cov_report, args)
+    if args.action == 'report':
+        return report.post_report(cov_report, args)
+    elif args.action == 'finsh-report':
+        return report.finish_report(args)
+    else:
+        raise ValueError("Not supported action")

--- a/cpp_coveralls/__init__.py
+++ b/cpp_coveralls/__init__.py
@@ -110,7 +110,7 @@ def run():
 
     if args.action == 'report':
         return report.post_report(cov_report, args)
-    elif args.action == 'finsh-report':
+    elif args.action == 'finish-report':
         return report.finish_report(args)
     else:
         raise ValueError("Not supported action")

--- a/cpp_coveralls/__init__.py
+++ b/cpp_coveralls/__init__.py
@@ -97,18 +97,17 @@ def run():
         raise ValueError("\nno coveralls.io token specified and no travis job id found\n"
                          "see --help for examples on how to specify a token\n")
 
-    if not args.no_gcov:
-        coverage.run_gcov(args)
-    cov_report = coverage.collect(args)
-    if args.verbose:
-        print(cov_report)
-    if args.dryrun:
-        return 0
-    if args.dump:
-        args.dump.write(json.dumps(cov_report))
-        return 0
-
     if args.action == 'report':
+        if not args.no_gcov:
+            coverage.run_gcov(args)
+        cov_report = coverage.collect(args)
+        if args.verbose:
+            print(cov_report)
+        if args.dryrun:
+            return 0
+        if args.dump:
+            args.dump.write(json.dumps(cov_report))
+            return 0
         return report.post_report(cov_report, args)
     elif args.action == 'finish-report':
         return report.finish_report(args)

--- a/cpp_coveralls/__init__.py
+++ b/cpp_coveralls/__init__.py
@@ -73,7 +73,8 @@ def run():
         # use environment COVERALLS_REPO_TOKEN as a fallback
         args.repo_token = os.environ.get('COVERALLS_REPO_TOKEN')
 
-    args.service_name = yml.get('service_name', 'travis-ci')
+    if args.service_name is None:
+        args.service_name = yml.get('service_name', 'travis-ci')
 
     if not args.gcov_options:
         args.gcov_options = yml.get('gcov_options', '')
@@ -86,7 +87,8 @@ def run():
     args.include.extend(yml.get('include', []))
     args.exclude_lines_pattern.extend(yml.get('exclude_lines_pattern', []))
 
-    args.service_job_id = os.environ.get('TRAVIS_JOB_ID', '')
+    if args.service_job_id is None:
+        args.service_job_id = os.environ.get('TRAVIS_JOB_ID', '')
 
     if args.repo_token == '' and args.service_job_id == '':
         raise ValueError("\nno coveralls.io token specified and no travis job id found\n"

--- a/cpp_coveralls/__init__.py
+++ b/cpp_coveralls/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 __author__ = 'Lei Xu <eddyxu@gmail.com>'
-__version__ = '0.4.2'
+__version__ = '0.4.3'
 
 __classifiers__ = [
     'Development Status :: 3 - Alpha',

--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -89,7 +89,7 @@ def create_args(params):
     parser.add_argument('--service-name', type=str, default=None, help="CI service name")
     parser.add_argument('--service-job-id', type=str, default=None, help="CI job ID")
     parser.add_argument('--parallel', action='store_true', help="Send a few reports and merge")
-    parser.add_argument('action', type=str, default='report', choices=['report', 'finish-report'], help="If the --parallel reports were used, the reports has to be finalized with a 'finish-report' action")
+    parser.add_argument('action', type=str, default='report', nargs='?', choices=['report', 'finish-report'], help="If the --parallel reports were used, the reports has to be finalized with a 'finish-report' action")
 
     return parser.parse_args(params)
 

--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -86,6 +86,8 @@ def create_args(params):
                         help='skip ssl certificate verification when '
                         'communicating with the coveralls server',
                         action='store_true', default=False)
+    parser.add_argument('--service-name', type=str, default=None)
+    parser.add_argument('--service-job-id', type=str, default=None)
 
     return parser.parse_args(params)
 

--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -86,8 +86,10 @@ def create_args(params):
                         help='skip ssl certificate verification when '
                         'communicating with the coveralls server',
                         action='store_true', default=False)
-    parser.add_argument('--service-name', type=str, default=None)
-    parser.add_argument('--service-job-id', type=str, default=None)
+    parser.add_argument('--service-name', type=str, default=None, help="CI service name")
+    parser.add_argument('--service-job-id', type=str, default=None, help="CI job ID")
+    parser.add_argument('--parallel', action='store_true', help="Send a few reports and merge")
+    parser.add_argument('action', type=str, default='report', choices=['report', 'finish-report'], help="If the --parallel reports were used, the reports has to be finalized with a 'finish-report' action")
 
     return parser.parse_args(params)
 
@@ -384,8 +386,8 @@ def collect(args):
     report['service_name'] = args.service_name
     report['service_job_id'] = args.service_job_id
 
-    if os.getenv('COVERALLS_PARALLEL', False):
-        report['parallel'] = 'true'
+    if args.parallel:
+        report['parallel'] = args.parallel
 
     args.exclude_lines_pattern.extend([
         r'\bLCOV_EXCL_LINE\b',

--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -88,7 +88,7 @@ def create_args(params):
                         action='store_true', default=False)
     parser.add_argument('--service-name', type=str, default=None, help="The CI service or other environment in which the test suite was run. This can be anything, but certain services have special features (travis-ci, travis-pro, or coveralls-ruby).")
     parser.add_argument('--service-job-id', type=str, default=None, help="A unique identifier of the job on the service specified by service_name.")
-    parser.add_argument('--service-number', type=str, default=None, help="The build number. Will default to chronological numbering from builds on repo.")
+    parser.add_argument('--service-build-number', type=str, default=None, help="The build number. Will default to chronological numbering from builds on repo.")
     parser.add_argument('--parallel', action='store_true', help="Send a few reports and merge")
     parser.add_argument('action', type=str, default='report', nargs='?', choices=['report', 'finish-report'], help="If the --parallel reports were used, the reports has to be finalized with a 'finish-report' action.")
 
@@ -387,8 +387,8 @@ def collect(args):
     report['service_name'] = args.service_name
     report['service_job_id'] = args.service_job_id
 
-    if args.service_number:
-        report['service_number'] = args.service_number
+    if args.service_build_number:
+        report['service_number'] = args.service_build_number
 
     if args.parallel:
         report['parallel'] = args.parallel

--- a/cpp_coveralls/coverage.py
+++ b/cpp_coveralls/coverage.py
@@ -86,10 +86,11 @@ def create_args(params):
                         help='skip ssl certificate verification when '
                         'communicating with the coveralls server',
                         action='store_true', default=False)
-    parser.add_argument('--service-name', type=str, default=None, help="CI service name")
-    parser.add_argument('--service-job-id', type=str, default=None, help="CI job ID")
+    parser.add_argument('--service-name', type=str, default=None, help="The CI service or other environment in which the test suite was run. This can be anything, but certain services have special features (travis-ci, travis-pro, or coveralls-ruby).")
+    parser.add_argument('--service-job-id', type=str, default=None, help="A unique identifier of the job on the service specified by service_name.")
+    parser.add_argument('--service-number', type=str, default=None, help="The build number. Will default to chronological numbering from builds on repo.")
     parser.add_argument('--parallel', action='store_true', help="Send a few reports and merge")
-    parser.add_argument('action', type=str, default='report', nargs='?', choices=['report', 'finish-report'], help="If the --parallel reports were used, the reports has to be finalized with a 'finish-report' action")
+    parser.add_argument('action', type=str, default='report', nargs='?', choices=['report', 'finish-report'], help="If the --parallel reports were used, the reports has to be finalized with a 'finish-report' action.")
 
     return parser.parse_args(params)
 
@@ -385,6 +386,9 @@ def collect(args):
 
     report['service_name'] = args.service_name
     report['service_job_id'] = args.service_job_id
+
+    if args.service_number:
+        report['service_number'] = args.service_number
 
     if args.parallel:
         report['parallel'] = args.parallel

--- a/cpp_coveralls/report.py
+++ b/cpp_coveralls/report.py
@@ -32,6 +32,6 @@ def finish_report(args):
         verify=(not args.skip_ssl_verify))
 
     if response.status_code != 200:
-        return response.reason
+        return response.status_code, response.reason, data
     else:
         return 0

--- a/cpp_coveralls/report.py
+++ b/cpp_coveralls/report.py
@@ -27,7 +27,7 @@ def post_report(coverage, args):
 def finish_report(args):
     """Finish a parallel reporting: https://docs.coveralls.io/parallel-build-webhook"""
     api_endpoint = f'{ENDPOINT}/webhook?repo_token={args.repo_token}'
-    data = {'payload':{'build_num': args.service_job_id,'status':'done'}}
+    data = {'payload[build_num]': args.service_number, 'payload[status]':'done'}
     response = requests.post(api_endpoint, data=data,
         verify=(not args.skip_ssl_verify))
 

--- a/cpp_coveralls/report.py
+++ b/cpp_coveralls/report.py
@@ -27,7 +27,7 @@ def post_report(coverage, args):
 def finish_report(args):
     """Finish a parallel reporting: https://docs.coveralls.io/parallel-build-webhook"""
     api_endpoint = f'{ENDPOINT}/webhook?repo_token={args.repo_token}'
-    data = {'payload[build_num]': args.service_number, 'payload[status]':'done'}
+    data = {'payload[build_num]': args.service_build_number, 'payload[status]':'done'}
     response = requests.post(api_endpoint, data=data,
         verify=(not args.skip_ssl_verify))
 

--- a/cpp_coveralls/report.py
+++ b/cpp_coveralls/report.py
@@ -5,11 +5,12 @@ import requests
 import json
 import os
 
-URL = os.getenv('COVERALLS_ENDPOINT', 'https://coveralls.io') + "/api/v1/jobs"
+ENDPOINT = os.getenv('COVERALLS_ENDPOINT', 'https://coveralls.io')
 
 def post_report(coverage, args):
     """Post coverage report to coveralls.io."""
-    response = requests.post(URL, files={'json_file': json.dumps(coverage)},
+    api_endpoint = f'{ENDPOINT}/api/v1/jobs'
+    response = requests.post(api_endpoint, files={'json_file': json.dumps(coverage)},
                              verify=(not args.skip_ssl_verify))
     try:
         result = response.json()
@@ -22,3 +23,15 @@ def post_report(coverage, args):
     if 'error' in result:
         return result['error']
     return 0
+
+def finish_report(args):
+    """Finish a parallel reporting: https://docs.coveralls.io/parallel-build-webhook"""
+    api_endpoint = f'{ENDPOINT}/webhook?repo_token={args.repo_token}'
+    data = {'payload':{'build_num': args.service_job_id,'status':'done'}}
+    response = requests.post(api_endpoint, data=data,
+        verify=(not args.skip_ssl_verify))
+
+    if response.status_code != 200:
+        return response.json()['error']
+    else:
+        return 0

--- a/cpp_coveralls/report.py
+++ b/cpp_coveralls/report.py
@@ -32,6 +32,6 @@ def finish_report(args):
         verify=(not args.skip_ssl_verify))
 
     if response.status_code != 200:
-        return response.json()['error']
+        return response.reason
     else:
         return 0


### PR DESCRIPTION
thanks for providing this tool :-) 
we are using it in CI and we have made few additional features.
lately we found out that there is some discrepancies in coverage related to `parse_gcov_file` this issue was addressed (please see an example for one of those problematic `.gcov`). 

- since line 19 repeats multiple times within the same file, for each of those repetition the output would create another entry (another line) which shifts all the coverage report beyond this point!
- code for this fix is [in here](https://github.com/eddyxu/cpp-coveralls/blob/7ac19e715f7fdda39cc6bbe3a4782ac0c7c5ad4d/cpp_coveralls/coverage.py#L287-L311)

```
        -:   15:
        -:   16:class future_base_t
        -:   17:{
        -:   18:public:
    #####:   19:    virtual ~future_base_t() = default;
------------------
_ZN5async13future_base_tD0Ev:
    #####:   19:    virtual ~future_base_t() = default;
------------------
_ZN5async13future_base_tD2Ev:
    #####:   19:    virtual ~future_base_t() = default;
------------------
        -:   20:    virtual void cancel() = 0;
        -:   21:};
        -: 
```


on top of that, I'm sharing other feature we have added to coveralls 
- `--parallel` in report  
- `finish_report` for competing a parallel report